### PR TITLE
Fix grpc planner

### DIFF
--- a/up_aries/grpc_server.py
+++ b/up_aries/grpc_server.py
@@ -131,16 +131,15 @@ class GRPCPlanner(engines.engine.Engine, mixins.OneshotPlannerMixin):
 
         req = proto.PlanRequest(problem=proto_problem, timeout=timeout)
         response_stream = self._planner.planOneShot(req)
-        for response in response_stream:
-            response = self._reader.convert(response, problem)
-            assert isinstance(response, up.engines.results.PlanGenerationResult)
-            if (
-                response.status == PlanGenerationResultStatus.INTERMEDIATE
-                and callback is not None
-            ):
-                callback(response)
-            else:
-                return response
+        response = self._reader.convert(response_stream, problem)
+        assert isinstance(response, up.engines.results.PlanGenerationResult)
+        if (
+            response.status == PlanGenerationResultStatus.INTERMEDIATE
+            and callback is not None
+        ):
+            callback(response)
+        else:
+            return response
 
     def _grpc_server_on(self, channel) -> bool:
         """Check if the grpc server is available

--- a/up_aries/grpc_server.py
+++ b/up_aries/grpc_server.py
@@ -42,6 +42,9 @@ class GRPCPlanner(engines.engine.Engine, mixins.OneshotPlannerMixin):
         :type timeout: Optional[float], optional
         :raises UPException: If the gRPC server is not available or accessible
         """
+        engines.Engine.__init__(self)
+        mixins.OneshotPlannerMixin.__init__(self)
+
         self._host = host
         self._port = port
         self._override = override


### PR DESCRIPTION
Aries failed on simple test examples because of two problems in the GRPCPlanner, e.g., with:

``` Python
    aries = Aries()
    problem = get_example_problems()["htn-go"].problem
    result = aries.solve(problem)
    print(result.plan)
```

`aries_solve(problem)` first failed with AttributeError: 'Aries' object has no attribute 'optimality_metric_required'.
This is resolved with the first commit.

Afterwards, it failed with a TypeError in the `_solve()` which is addressed in the second commit.
The second commit works for such simple examples.

However,  I could not test the case where the callback is used and 
`response.status == PlanGenerationResultStatus.INTERMEDIATE`.
Therefore, I  am not sure if that case results in the expected behavior.